### PR TITLE
Eodhp 233 triggering tests in testkube using testkube cli 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Creating Test
 * https://docs.testkube.io/articles/creating-tests
 
-` testkube create test --name <testname> --type curl/test --file component-curl-test.json`
+` testkube create test --name <testname> --type curl/test --file component-curl-test.json --variable BASE_URL=<base url to be tested> `
 
 The ` component-curl-test.json ` is in ` /env/tests/ ` folder. Once above command is run the following output will be displayed
 
@@ -36,7 +36,7 @@ The test names given below are added to testsuite, therefore users/developers ca
 | data-provider1  | dataprovider1-test |
 
 ### creating test with schedule
-` kubectl testkube create test --file <filename json> --name scheduled-test --variable BASE_URL=<base url to be tested> --schedule="*/1 * * * *" `
+` kubectl testkube create test --file <filename json> --name <scheduled-test-name> --variable BASE_URL=<base url to be tested> --schedule="*/1 * * * *" `
 
 ## Updating test
  testnames are unique, no two test can be created with same name, but the test content can be updated using bellow command
@@ -122,10 +122,32 @@ all tests in the above scripts should be created before running the testsuite sc
 
 
 # Test triggers
-
+[testkube test triggers](https://docs.testkube.io/articles/test-triggers)
 Test triggers are created as Custom Resources, they needs to be defined in yaml file
 
-` kubectl apply -f <yamlfilepath> `
+` kubectl apply -f /eodhp-system-tests/test-triggers/test-triggers.yaml `
+
+The test trigger yaml file can be found under ` /eodhp-system-tests/test-triggers ` folder, more than one trigger is created in the same file ` test-trigger.yaml` separated by ` --- `
+
+The tests or testsuites can be triggered with an action (run) when a resource (pod, deployment, statefulset, deamonset, service, ingress, event, configmap) event (create, modify, delete) takes place.
+
+## delete test trigger
+
+` kubectl delete -f /eodhp-system-tests/test-triggers/test-triggers.yaml `
+
+## test labels
+Label selectors are used when we want to select a group of resources in a specific namespace.
+
+```yaml
+selector:
+  namespace: Kubernetes object namespace (default is **testkube**)
+  labelSelector:
+    matchLabels: map of key-value pairs
+    matchExpressions:
+      - key: environment                 # label name
+        operator: In                     # possible values "In | NotIn | Exists | DoesNotExist"
+        values: [dev]                    # value(s)
+```
 
 
 # Supported test types/executors within Testkube

--- a/README.md
+++ b/README.md
@@ -2,18 +2,14 @@
 
 ## Prerequisites
 
-
-- Teskube CLI is installed (https://docs.testkube.io/articles/install-cli)
-- 
+- Teskube CLI is installed [testkube cli install](https://docs.testkube.io/articles/install-cli)
 
 ## Creating First Test
-  https://docs.testkube.io/articles/creating-first-test
+  [first test in testkube](https://docs.testkube.io/articles/creating-first-test)
   
  - CLI - manual test execution
    [https://httpbin.test.k6.io/](https://docs.testkube.io/articles/creating-first-test#cli)
    
- - Changing output format
-   https://docs.testkube.io/articles/creating-first-test#changing-the-output-format
 
 ## Creating Test
 * https://docs.testkube.io/articles/creating-tests
@@ -48,7 +44,6 @@ The test names given below are added to testsuite, therefore users/developers ca
 ` testkube update test --name <testname> --file <testjsonfilepath> --timeout 10 `
 
 where the timeout value is seconds.
-
 
 
 ## Running a test

--- a/eodhp-system-tests/test-triggers/test-trigger.yaml
+++ b/eodhp-system-tests/test-triggers/test-trigger.yaml
@@ -1,0 +1,37 @@
+apiVersion: tests.testkube.io/v1
+kind: TestTrigger
+metadata:
+  name: apphub-modified-trigger
+  namespace: testkube
+spec:
+  resource: deployment    # pod, deployment, statefulset, daemonset, service, ingress, event, configmap
+  resourceSelector:
+    name: application-hub-hub-5c7d99ccf7-4rrw5
+    namespace: proc
+  execution: test
+  event: modified
+  action: run
+  delay: 30s
+  testSelector:
+    name: apphubtest    ## or testsuite
+    namespace: testkube
+
+---
+
+apiVersion: tests.testkube.io/v1
+kind: TestTrigger
+metadata:
+  name: eoxvs-modified-trigger
+  namespace: testkube
+spec:
+  resource: deployment    # pod, deployment, statefulset, daemonset, service, ingress, event, configmap
+  resourceSelector:
+    name: eoxvs-harvester-584b8bc8bd-jfkl6
+    namespace: proc
+  execution: testsuite
+  event: modified
+  action: run
+  delay: 30s
+  testSelector:
+    name: testkube-suite
+    namespace: testkube


### PR DESCRIPTION
PR for the changes I have done in Readme.md and the test triggers I have tested.

Two component in Eodhp has been tested using "resourceSelector", future updates needed to be able to trigger tests based on their labels. So this PR should be considered as an interim update in test trigger functionality, where in final configuration the tests should be triggered by scheduling and/or by labelSelector property of the tests.